### PR TITLE
Thread safe node.destroy_*

### DIFF
--- a/rclpy/rclpy/action/server.py
+++ b/rclpy/rclpy/action/server.py
@@ -247,10 +247,10 @@ class ActionServer(Waitable):
         check_for_type_support(action_type)
         self._node = node
         self._action_type = action_type
-        with node.handle as node_capsule:
+        with node.handle as node_capsule, node.get_clock().handle as clock_capsule:
             self._handle = _rclpy_action.rclpy_action_create_server(
                 node_capsule,
-                node.get_clock().handle,
+                clock_capsule,
                 action_type,
                 action_name,
                 goal_service_qos_profile.get_c_qos_profile(),

--- a/rclpy/rclpy/publisher.py
+++ b/rclpy/rclpy/publisher.py
@@ -46,7 +46,7 @@ class Publisher:
         :param node_handle: Capsule pointing to the ``rcl_node_t`` object for the node the
             publisher is associated with.
         """
-        self.publisher_handle = publisher_handle
+        self.__handle = publisher_handle
         self.msg_type = msg_type
         self.topic = topic
         self.qos_profile = qos_profile
@@ -62,4 +62,12 @@ class Publisher:
         """
         if not isinstance(msg, self.msg_type):
             raise TypeError()
-        _rclpy.rclpy_publish(self.publisher_handle, msg)
+        with self.handle as capsule:
+            _rclpy.rclpy_publish(capsule, msg)
+
+    @property
+    def handle(self):
+        return self.__handle
+
+    def destroy(self):
+        self.handle.destroy()

--- a/rclpy/rclpy/service.py
+++ b/rclpy/rclpy/service.py
@@ -30,7 +30,6 @@ class Service:
         self,
         node_handle,
         service_handle,
-        service_pointer: int,
         srv_type: SrvType,
         srv_name: str,
         callback: Callable[[SrvTypeRequest, SrvTypeResponse], SrvTypeResponse],
@@ -47,7 +46,6 @@ class Service:
             with the service server.
         :param context: The context associated with the service server.
         :param service_handle: Capsule pointing to the underlying ``rcl_service_t`` object.
-        :param service_pointer: Memory address of the ``rcl_service_t`` implementation.
         :param srv_type: The service type.
         :param srv_name: The name of the service.
         :param callback_group: The callback group for the service server. If ``None``, then the
@@ -55,8 +53,7 @@ class Service:
         :param qos_profile: The quality of service profile to apply the service server.
         """
         self.node_handle = node_handle
-        self.service_handle = service_handle
-        self.service_pointer = service_pointer
+        self.__handle = service_handle
         self.srv_type = srv_type
         self.srv_name = srv_name
         self.callback = callback
@@ -77,4 +74,12 @@ class Service:
         """
         if not isinstance(response, self.srv_type.Response):
             raise TypeError()
-        _rclpy.rclpy_send_response(self.service_handle, response, header)
+        with self.handle as capsule:
+            _rclpy.rclpy_send_response(capsule, response, header)
+
+    @property
+    def handle(self):
+        return self.__handle
+
+    def destroy(self):
+        self.handle.destroy()

--- a/rclpy/rclpy/timer.py
+++ b/rclpy/rclpy/timer.py
@@ -14,6 +14,7 @@
 
 from rclpy.clock import Clock
 from rclpy.clock import ClockType
+from rclpy.handle import Handle
 from rclpy.impl.implementation_singleton import rclpy_implementation as _rclpy
 from rclpy.utilities import get_default_context
 
@@ -25,8 +26,10 @@ class WallTimer:
         self._context = get_default_context() if context is None else context
         # TODO(sloretz) Allow passing clocks in via timer constructor
         self._clock = Clock(clock_type=ClockType.STEADY_TIME)
-        [self.timer_handle, self.timer_pointer] = _rclpy.rclpy_create_timer(
-            self._clock._clock_handle, self._context.handle, timer_period_ns)
+        with self._clock.handle as clock_capsule:
+            self.__handle = Handle(_rclpy.rclpy_create_timer(
+                clock_capsule, self._context.handle, timer_period_ns))
+        self.__handle.requires(self._clock.handle)
         self.timer_period_ns = timer_period_ns
         self.callback = callback
         self.callback_group = callback_group
@@ -34,35 +37,50 @@ class WallTimer:
         self._executor_event = False
 
     @property
+    def handle(self):
+        return self.__handle
+
+    def destroy(self):
+        self.handle.destroy()
+
+    @property
     def clock(self):
         return self._clock
 
     @property
     def timer_period_ns(self):
-        val = _rclpy.rclpy_get_timer_period(self.timer_handle)
+        with self.handle as capsule:
+            val = _rclpy.rclpy_get_timer_period(capsule)
         self._timer_period_ns = val
         return val
 
     @timer_period_ns.setter
     def timer_period_ns(self, value):
         val = int(value)
-        _rclpy.rclpy_change_timer_period(self.timer_handle, val)
+        with self.handle as capsule:
+            _rclpy.rclpy_change_timer_period(capsule, val)
         self._timer_period_ns = val
 
     def is_ready(self):
-        return _rclpy.rclpy_is_timer_ready(self.timer_handle)
+        with self.handle as capsule:
+            return _rclpy.rclpy_is_timer_ready(capsule)
 
     def is_canceled(self):
-        return _rclpy.rclpy_is_timer_canceled(self.timer_handle)
+        with self.handle as capsule:
+            return _rclpy.rclpy_is_timer_canceled(capsule)
 
     def cancel(self):
-        _rclpy.rclpy_cancel_timer(self.timer_handle)
+        with self.handle as capsule:
+            _rclpy.rclpy_cancel_timer(capsule)
 
     def reset(self):
-        _rclpy.rclpy_reset_timer(self.timer_handle)
+        with self.handle as capsule:
+            _rclpy.rclpy_reset_timer(capsule)
 
     def time_since_last_call(self):
-        return _rclpy.rclpy_time_since_last_call(self.timer_handle)
+        with self.handle as capsule:
+            return _rclpy.rclpy_time_since_last_call(capsule)
 
     def time_until_next_call(self):
-        return _rclpy.rclpy_time_until_next_call(self.timer_handle)
+        with self.handle as capsule:
+            return _rclpy.rclpy_time_until_next_call(capsule)

--- a/rclpy/src/rclpy/_rclpy.c
+++ b/rclpy/src/rclpy/_rclpy.c
@@ -47,6 +47,30 @@ typedef struct
   rcl_node_t * node;
 } rclpy_subscription_t;
 
+typedef struct
+{
+  rcl_publisher_t publisher;
+  rcl_node_t * node;
+} rclpy_publisher_t;
+
+typedef struct
+{
+  // Important: a pointer to a structure is also a pointer to its first member.
+  // The client must be first in the struct to compare cli.handle.pointer to an address
+  // in a wait set.
+  rcl_client_t client;
+  rcl_node_t * node;
+} rclpy_client_t;
+
+typedef struct
+{
+  // Important: a pointer to a structure is also a pointer to its first member.
+  // The service must be first in the struct to compare srv.handle.pointer to an address
+  // in a wait set.
+  rcl_service_t service;
+  rcl_node_t * node;
+} rclpy_service_t;
+
 void
 _rclpy_context_capsule_destructor(PyObject * capsule)
 {
@@ -106,18 +130,41 @@ rclpy_create_context(PyObject * Py_UNUSED(self), PyObject * Py_UNUSED(args))
   return PyCapsule_New(context, "rcl_context_t", _rclpy_context_capsule_destructor);
 }
 
+/// PyCapsule destructor for guard condition
+static void
+_rclpy_destroy_guard_condition(PyObject * pyentity)
+{
+  rcl_guard_condition_t * gc = (rcl_guard_condition_t *)PyCapsule_GetPointer(
+    pyentity, "rcl_guard_condition_t");
+  if (!gc) {
+    // Don't want to raise an exception, who knows where it will get raised.
+    PyErr_Clear();
+    // Warning should use line number of the current stack frame
+    int stack_level = 1;
+    PyErr_WarnFormat(
+      PyExc_RuntimeWarning, stack_level, "_rclpy_destroy_guard_condition failed to get pointer");
+    return;
+  }
+
+  rcl_ret_t ret = rcl_guard_condition_fini(gc);
+  if (RCL_RET_OK != ret) {
+    // Warning should use line number of the current stack frame
+    int stack_level = 1;
+    PyErr_WarnFormat(
+      PyExc_RuntimeWarning, stack_level, "Failed to fini guard condition: %s",
+      rcl_get_error_string().str);
+  }
+  PyMem_Free(gc);
+}
+
 /// Create a general purpose guard condition
 /**
- * A successful call will return a list with two elements:
- *
- * - a Capsule with the pointer of the created rcl_guard_condition_t * structure
- * - an integer representing the memory address of the rcl_guard_condition_t
+ * A successful call will return a Capsule with the pointer of the created
+ * rcl_guard_condition_t * structure
  *
  * Raises RuntimeError if initializing the guard condition fails
  *
- * \remark Call rclpy_destroy_entity() to destroy a guard condition
- * \sa rclpy_destroy_entity()
- * \return a list with the capsule and memory location, or
+ * \return a capsule, or
  * \return NULL on failure
  */
 static PyObject *
@@ -152,33 +199,13 @@ rclpy_create_guard_condition(PyObject * Py_UNUSED(self), PyObject * args)
     return NULL;
   }
 
-  PyObject * pylist = PyList_New(2);
-  if (!pylist) {
-    ret = rcl_guard_condition_fini(gc);
-    PyMem_Free(gc);
-    return NULL;
-  }
-
-  PyObject * pygc = PyCapsule_New(gc, "rcl_guard_condition_t", NULL);
+  PyObject * pygc = PyCapsule_New(gc, "rcl_guard_condition_t", _rclpy_destroy_guard_condition);
   if (!pygc) {
     ret = rcl_guard_condition_fini(gc);
     PyMem_Free(gc);
-    Py_DECREF(pylist);
     return NULL;
   }
-
-  PyObject * pygc_reference = PyLong_FromVoidPtr(gc);
-  if (!pygc_reference) {
-    ret = rcl_guard_condition_fini(gc);
-    PyMem_Free(gc);
-    Py_DECREF(pylist);
-    Py_DECREF(pygc);
-    return NULL;
-  }
-
-  PyList_SET_ITEM(pylist, 0, pygc);
-  PyList_SET_ITEM(pylist, 1, pygc_reference);
-  return pylist;
+  return pygc;
 }
 
 /// Trigger a general purpose guard condition
@@ -1168,6 +1195,33 @@ rclpy_expand_topic_name(PyObject * Py_UNUSED(self), PyObject * args)
   return result;
 }
 
+/// PyCapsule destructor for publisher
+static void
+_rclpy_destroy_publisher(PyObject * pyentity)
+{
+  rclpy_publisher_t * pub = (rclpy_publisher_t *)PyCapsule_GetPointer(
+    pyentity, "rclpy_publisher_t");
+  if (!pub) {
+    // Don't want to raise an exception, who knows where it will get raised.
+    PyErr_Clear();
+    // Warning should use line number of the current stack frame
+    int stack_level = 1;
+    PyErr_WarnFormat(
+      PyExc_RuntimeWarning, stack_level, "_rclpy_destroy_publisher failed to get pointer");
+    return;
+  }
+
+  rcl_ret_t ret = rcl_publisher_fini(&(pub->publisher), pub->node);
+  if (RCL_RET_OK != ret) {
+    // Warning should use line number of the current stack frame
+    int stack_level = 1;
+    PyErr_WarnFormat(
+      PyExc_RuntimeWarning, stack_level, "Failed to fini publisher: %s",
+      rcl_get_error_string().str);
+  }
+  PyMem_Free(pub);
+}
+
 /// Create a publisher
 /**
  * This function will create a publisher and attach it to the provided topic name
@@ -1241,14 +1295,15 @@ rclpy_create_publisher(PyObject * Py_UNUSED(self), PyObject * args)
     }
   }
 
-  rcl_publisher_t * publisher = (rcl_publisher_t *)PyMem_Malloc(sizeof(rcl_publisher_t));
-  if (!publisher) {
+  rclpy_publisher_t * pub = (rclpy_publisher_t *)PyMem_Malloc(sizeof(rclpy_publisher_t));
+  if (!pub) {
     PyErr_Format(PyExc_MemoryError, "Failed to allocate memory for publisher");
     return NULL;
   }
-  *publisher = rcl_get_zero_initialized_publisher();
+  pub->publisher = rcl_get_zero_initialized_publisher();
+  pub->node = node;
 
-  rcl_ret_t ret = rcl_publisher_init(publisher, node, ts, topic, &publisher_ops);
+  rcl_ret_t ret = rcl_publisher_init(&(pub->publisher), node, ts, topic, &publisher_ops);
   if (ret != RCL_RET_OK) {
     if (ret == RCL_RET_TOPIC_NAME_INVALID) {
       PyErr_Format(PyExc_ValueError,
@@ -1259,10 +1314,10 @@ rclpy_create_publisher(PyObject * Py_UNUSED(self), PyObject * args)
         "Failed to create publisher: %s", rcl_get_error_string().str);
     }
     rcl_reset_error();
-    PyMem_Free(publisher);
+    PyMem_Free(pub);
     return NULL;
   }
-  return PyCapsule_New(publisher, "rcl_publisher_t", NULL);
+  return PyCapsule_New(pub, "rclpy_publisher_t", _rclpy_destroy_publisher);
 }
 
 /// Publish a message
@@ -1284,9 +1339,9 @@ rclpy_publish(PyObject * Py_UNUSED(self), PyObject * args)
     return NULL;
   }
 
-  rcl_publisher_t * publisher = (rcl_publisher_t *)PyCapsule_GetPointer(
-    pypublisher, "rcl_publisher_t");
-  if (!publisher) {
+  rclpy_publisher_t * pub = (rclpy_publisher_t *)PyCapsule_GetPointer(
+    pypublisher, "rclpy_publisher_t");
+  if (!pub) {
     return NULL;
   }
 
@@ -1296,7 +1351,7 @@ rclpy_publish(PyObject * Py_UNUSED(self), PyObject * args)
     return NULL;
   }
 
-  rcl_ret_t ret = rcl_publish(publisher, raw_ros_message);
+  rcl_ret_t ret = rcl_publish(&(pub->publisher), raw_ros_message);
   destroy_ros_message(raw_ros_message);
   if (ret != RCL_RET_OK) {
     PyErr_Format(PyExc_RuntimeError,
@@ -1308,12 +1363,37 @@ rclpy_publish(PyObject * Py_UNUSED(self), PyObject * args)
   Py_RETURN_NONE;
 }
 
+/// PyCapsule destructor for timer
+static void
+_rclpy_destroy_timer(PyObject * pyentity)
+{
+  rcl_timer_t * tmr = (rcl_timer_t *)PyCapsule_GetPointer(
+    pyentity, "rcl_timer_t");
+  if (!tmr) {
+    // Don't want to raise an exception, who knows where it will get raised.
+    PyErr_Clear();
+    // Warning should use line number of the current stack frame
+    int stack_level = 1;
+    PyErr_WarnFormat(
+      PyExc_RuntimeWarning, stack_level, "_rclpy_destroy_timer failed to get pointer");
+    return;
+  }
+
+  rcl_ret_t ret = rcl_timer_fini(tmr);
+  if (RCL_RET_OK != ret) {
+    // Warning should use line number of the current stack frame
+    int stack_level = 1;
+    PyErr_WarnFormat(
+      PyExc_RuntimeWarning, stack_level, "Failed to fini timer: %s",
+      rcl_get_error_string().str);
+  }
+  PyMem_Free(tmr);
+}
+
 /// Create a timer
 /**
- * When successful a list with two elements is returned:
- *
- * - a Capsule pointing to the pointer of the created rcl_timer_t * structure
- * - an integer representing the memory address of the created rcl_timer_t
+ * When successful a Capsule pointing to the pointer of the created rcl_timer_t * structure
+ * is returned
  *
  * On failure, an exception is raised and NULL is returned if:
  *
@@ -1324,7 +1404,7 @@ rclpy_publish(PyObject * Py_UNUSED(self), PyObject * args)
  * \param[in] clock pycapsule containing an rcl_clock_t
  * \param[in] period_nsec unsigned PyLong object storing the period of the
  *   timer in nanoseconds in a 64-bit unsigned integer
- * \return a list of the capsule and the memory address
+ * \return a capsule
  * \return NULL on failure
  */
 static PyObject *
@@ -1365,34 +1445,14 @@ rclpy_create_timer(PyObject * Py_UNUSED(self), PyObject * args)
     return NULL;
   }
 
-  PyObject * pylist = PyList_New(2);
-  if (!pylist) {
-    ret = rcl_timer_fini(timer);
-    (void)ret;
-    PyMem_Free(timer);
-    return NULL;
-  }
-  PyObject * pytimer = PyCapsule_New(timer, "rcl_timer_t", NULL);
+  PyObject * pytimer = PyCapsule_New(timer, "rcl_timer_t", _rclpy_destroy_timer);
   if (!pytimer) {
     ret = rcl_timer_fini(timer);
     (void)ret;
     PyMem_Free(timer);
-    Py_DECREF(pylist);
     return NULL;
   }
-  PyObject * pytimer_impl_reference = PyLong_FromUnsignedLongLong((uint64_t)&timer->impl);
-  if (!pytimer_impl_reference) {
-    ret = rcl_timer_fini(timer);
-    (void)ret;
-    PyMem_Free(timer);
-    Py_DECREF(pylist);
-    Py_DECREF(pytimer);
-    return NULL;
-  }
-  PyList_SET_ITEM(pylist, 0, pytimer);
-  PyList_SET_ITEM(pylist, 1, pytimer_impl_reference);
-
-  return pylist;
+  return pytimer;
 }
 
 /// Returns the period of the timer in nanoseconds
@@ -1832,16 +1892,41 @@ rclpy_create_subscription(PyObject * Py_UNUSED(self), PyObject * args)
   return pysubscription;
 }
 
+/// PyCapsule destructor for client
+static void
+_rclpy_destroy_client(PyObject * pyentity)
+{
+  rclpy_client_t * cli = (rclpy_client_t *)PyCapsule_GetPointer(
+    pyentity, "rclpy_client_t");
+  if (!cli) {
+    // Don't want to raise an exception, who knows where it will get raised.
+    PyErr_Clear();
+    // Warning should use line number of the current stack frame
+    int stack_level = 1;
+    PyErr_WarnFormat(
+      PyExc_RuntimeWarning, stack_level, "_rclpy_destroy_client failed to get pointer");
+    return;
+  }
+
+  rcl_ret_t ret = rcl_client_fini(&(cli->client), cli->node);
+  if (RCL_RET_OK != ret) {
+    // Warning should use line number of the current stack frame
+    int stack_level = 1;
+    PyErr_WarnFormat(
+      PyExc_RuntimeWarning, stack_level, "Failed to fini client: %s",
+      rcl_get_error_string().str);
+  }
+  PyMem_Free(cli);
+}
+
 /// Create a client
 /**
  * This function will create a client for the given service name.
  * This client will use the typesupport defined in the service module
  * provided as pysrv_type to send messages over the wire.
  *
- * On a successful call a list with two elements is returned:
- *
- * - a Capsule pointing to the pointer of the created rcl_client_t * structure
- * - an integer representing the memory address of the created rcl_client_t
+ * On a successful call a Capsule pointing to the pointer of the created rclpy_client_t * is
+ * returned.
  *
  * Raises ValueError if the capsules are not the correct types
  * Raises RuntimeError if the client could not be created
@@ -1850,7 +1935,7 @@ rclpy_create_subscription(PyObject * Py_UNUSED(self), PyObject * args)
  * \param[in] pysrv_type Service module associated with the client
  * \param[in] pyservice_name Python object containing the service name
  * \param[in] pyqos_profile QoSProfile Python object for this client
- * \return capsule and memory address, or
+ * \return capsule or,
  * \return NULL on failure
  */
 static PyObject *
@@ -1908,14 +1993,15 @@ rclpy_create_client(PyObject * Py_UNUSED(self), PyObject * args)
     }
   }
 
-  rcl_client_t * client = (rcl_client_t *)PyMem_Malloc(sizeof(rcl_client_t));
+  rclpy_client_t * client = (rclpy_client_t *)PyMem_Malloc(sizeof(rclpy_client_t));
   if (!client) {
     PyErr_Format(PyExc_MemoryError, "Failed to allocate memory for client");
     return NULL;
   }
-  *client = rcl_get_zero_initialized_client();
+  client->client = rcl_get_zero_initialized_client();
+  client->node = node;
 
-  rcl_ret_t ret = rcl_client_init(client, node, ts, service_name, &client_ops);
+  rcl_ret_t ret = rcl_client_init(&(client->client), node, ts, service_name, &client_ops);
   if (ret != RCL_RET_OK) {
     if (ret == RCL_RET_SERVICE_NAME_INVALID) {
       PyErr_Format(PyExc_ValueError,
@@ -1929,34 +2015,15 @@ rclpy_create_client(PyObject * Py_UNUSED(self), PyObject * args)
     PyMem_Free(client);
     return NULL;
   }
-  PyObject * pylist = PyList_New(2);
-  if (!pylist) {
-    ret = rcl_client_fini(client, node);
-    (void)ret;
-    PyMem_Free(client);
-    return NULL;
-  }
-  PyObject * pyclient = PyCapsule_New(client, "rcl_client_t", NULL);
+  PyObject * pyclient = PyCapsule_New(client, "rclpy_client_t", _rclpy_destroy_client);
   if (!pyclient) {
-    ret = rcl_client_fini(client, node);
+    ret = rcl_client_fini(&(client->client), node);
     (void)ret;
     PyMem_Free(client);
-    Py_DECREF(pylist);
     return NULL;
   }
-  PyObject * pyclient_impl_reference = PyLong_FromUnsignedLongLong((uint64_t)&client->impl);
-  if (!pyclient_impl_reference) {
-    ret = rcl_client_fini(client, node);
-    (void)ret;
-    PyMem_Free(client);
-    Py_DECREF(pylist);
-    Py_DECREF(pyclient);
-    return NULL;
-  }
-  PyList_SET_ITEM(pylist, 0, pyclient);
-  PyList_SET_ITEM(pylist, 1, pyclient_impl_reference);
 
-  return pylist;
+  return pyclient;
 }
 
 /// Publish a request message
@@ -1977,7 +2044,7 @@ rclpy_send_request(PyObject * Py_UNUSED(self), PyObject * args)
   if (!PyArg_ParseTuple(args, "OO", &pyclient, &pyrequest)) {
     return NULL;
   }
-  rcl_client_t * client = (rcl_client_t *)PyCapsule_GetPointer(pyclient, "rcl_client_t");
+  rclpy_client_t * client = (rclpy_client_t *)PyCapsule_GetPointer(pyclient, "rclpy_client_t");
   if (!client) {
     return NULL;
   }
@@ -1989,7 +2056,7 @@ rclpy_send_request(PyObject * Py_UNUSED(self), PyObject * args)
   }
 
   int64_t sequence_number;
-  rcl_ret_t ret = rcl_send_request(client, raw_ros_request, &sequence_number);
+  rcl_ret_t ret = rcl_send_request(&(client->client), raw_ros_request, &sequence_number);
   destroy_ros_message(raw_ros_request);
   if (ret != RCL_RET_OK) {
     PyErr_Format(PyExc_RuntimeError,
@@ -2001,6 +2068,33 @@ rclpy_send_request(PyObject * Py_UNUSED(self), PyObject * args)
   return PyLong_FromLongLong(sequence_number);
 }
 
+/// PyCapsule destructor for service
+static void
+_rclpy_destroy_service(PyObject * pyentity)
+{
+  rclpy_service_t * srv = (rclpy_service_t *)PyCapsule_GetPointer(
+    pyentity, "rclpy_service_t");
+  if (!srv) {
+    // Don't want to raise an exception, who knows where it will get raised.
+    PyErr_Clear();
+    // Warning should use line number of the current stack frame
+    int stack_level = 1;
+    PyErr_WarnFormat(
+      PyExc_RuntimeWarning, stack_level, "_rclpy_destroy_service failed to get pointer");
+    return;
+  }
+
+  rcl_ret_t ret = rcl_service_fini(&(srv->service), srv->node);
+  if (RCL_RET_OK != ret) {
+    // Warning should use line number of the current stack frame
+    int stack_level = 1;
+    PyErr_WarnFormat(
+      PyExc_RuntimeWarning, stack_level, "Failed to fini service: %s",
+      rcl_get_error_string().str);
+  }
+  PyMem_Free(srv);
+}
+
 /// Create a service server
 /**
  * This function will create a service server for the given service name.
@@ -2008,10 +2102,8 @@ rclpy_send_request(PyObject * Py_UNUSED(self), PyObject * args)
  * provided as pysrv_type to send messages over the wire.
  *
  *
- * On a successful call a list with two elements is returned:
- *
- * - a Capsule pointing to the pointer of the created rcl_service_t * structure
- * - an integer representing the memory address of the created rcl_service_t
+ * On a successful call a Capsule pointing to the pointer of the created rcl_service_t *
+ * is returned.
  *
  * Raises ValueError if the capsules are not the correct types
  * Raises RuntimeError if the service could not be created
@@ -2020,7 +2112,7 @@ rclpy_send_request(PyObject * Py_UNUSED(self), PyObject * args)
  * \param[in] pysrv_type Service module associated with the service
  * \param[in] pyservice_name Python object for the service name
  * \param[in] pyqos_profile QoSProfile Python object for this service
- * \return capsule and memory address, or
+ * \return capsule, or
  * \return NULL on failure
  */
 static PyObject *
@@ -2078,13 +2170,15 @@ rclpy_create_service(PyObject * Py_UNUSED(self), PyObject * args)
     }
   }
 
-  rcl_service_t * service = (rcl_service_t *)PyMem_Malloc(sizeof(rcl_service_t));
-  if (!service) {
+  rclpy_service_t * srv = (rclpy_service_t *)PyMem_Malloc(sizeof(rclpy_service_t));
+  if (!srv) {
     PyErr_Format(PyExc_MemoryError, "Failed to allocate memory for service");
     return NULL;
   }
-  *service = rcl_get_zero_initialized_service();
-  rcl_ret_t ret = rcl_service_init(service, node, ts, service_name, &service_ops);
+  srv->service = rcl_get_zero_initialized_service();
+  srv->node = node;
+
+  rcl_ret_t ret = rcl_service_init(&(srv->service), node, ts, service_name, &service_ops);
   if (ret != RCL_RET_OK) {
     if (ret == RCL_RET_SERVICE_NAME_INVALID) {
       PyErr_Format(PyExc_ValueError,
@@ -2094,39 +2188,19 @@ rclpy_create_service(PyObject * Py_UNUSED(self), PyObject * args)
       PyErr_Format(PyExc_RuntimeError,
         "Failed to create service: %s", rcl_get_error_string().str);
     }
-    PyMem_Free(service);
+    PyMem_Free(srv);
     rcl_reset_error();
     return NULL;
   }
 
-  PyObject * pylist = PyList_New(2);
-  if (!pylist) {
-    ret = rcl_service_fini(service, node);
-    (void)ret;
-    PyMem_Free(service);
-    return NULL;
-  }
-  PyObject * pyservice = PyCapsule_New(service, "rcl_service_t", NULL);
+  PyObject * pyservice = PyCapsule_New(srv, "rclpy_service_t", _rclpy_destroy_service);
   if (!pyservice) {
-    ret = rcl_service_fini(service, node);
+    ret = rcl_service_fini(&(srv->service), node);
     (void)ret;
-    PyMem_Free(service);
-    Py_DECREF(pylist);
+    PyMem_Free(srv);
     return NULL;
   }
-  PyObject * pyservice_impl_reference = PyLong_FromUnsignedLongLong((uint64_t)&service->impl);
-  if (!pyservice_impl_reference) {
-    ret = rcl_service_fini(service, node);
-    (void)ret;
-    PyMem_Free(service);
-    Py_DECREF(pylist);
-    Py_DECREF(pyservice);
-    return NULL;
-  }
-  PyList_SET_ITEM(pylist, 0, pyservice);
-  PyList_SET_ITEM(pylist, 1, pyservice_impl_reference);
-
-  return pylist;
+  return pyservice;
 }
 
 /// Publish a response message
@@ -2149,9 +2223,8 @@ rclpy_send_response(PyObject * Py_UNUSED(self), PyObject * args)
   if (!PyArg_ParseTuple(args, "OOO", &pyservice, &pyresponse, &pyheader)) {
     return NULL;
   }
-  rcl_service_t * service = (rcl_service_t *)PyCapsule_GetPointer(
-    pyservice, "rcl_service_t");
-  if (!service) {
+  rclpy_service_t * srv = (rclpy_service_t *)PyCapsule_GetPointer(pyservice, "rclpy_service_t");
+  if (!srv) {
     return NULL;
   }
 
@@ -2167,7 +2240,7 @@ rclpy_send_response(PyObject * Py_UNUSED(self), PyObject * args)
     return NULL;
   }
 
-  rcl_ret_t ret = rcl_send_response(service, header, raw_ros_response);
+  rcl_ret_t ret = rcl_send_response(&(srv->service), header, raw_ros_response);
   destroy_ros_message(raw_ros_response);
   if (ret != RCL_RET_OK) {
     PyErr_Format(PyExc_RuntimeError,
@@ -2200,13 +2273,13 @@ rclpy_service_server_is_available(PyObject * Py_UNUSED(self), PyObject * args)
   if (!node) {
     return NULL;
   }
-  rcl_client_t * client = (rcl_client_t *)PyCapsule_GetPointer(pyclient, "rcl_client_t");
+  rclpy_client_t * client = (rclpy_client_t *)PyCapsule_GetPointer(pyclient, "rclpy_client_t");
   if (!client) {
     return NULL;
   }
 
   bool is_ready;
-  rcl_ret_t ret = rcl_service_server_is_available(node, client, &is_ready);
+  rcl_ret_t ret = rcl_service_server_is_available(node, &(client->client), &is_ready);
 
   if (ret != RCL_RET_OK) {
     PyErr_Format(PyExc_RuntimeError,
@@ -2221,141 +2294,32 @@ rclpy_service_server_is_available(PyObject * Py_UNUSED(self), PyObject * args)
   Py_RETURN_FALSE;
 }
 
-/// Destroy an entity attached to a node
-/**
- * Entity type must be one of ["publisher", "client", "service"].
- *
- * Raises RuntimeError on failure
- *
- * \param[in] pyentity Capsule pointing to the entity to destroy
- * \param[in] pynode Capsule pointing to the node the entity belongs to
- */
-static PyObject *
-rclpy_destroy_node_entity(PyObject * Py_UNUSED(self), PyObject * args)
-{
-  PyObject * pyentity;
-  PyObject * pynode;
-
-  if (!PyArg_ParseTuple(args, "OO", &pyentity, &pynode)) {
-    return NULL;
-  }
-
-  rcl_node_t * node = (rcl_node_t *)PyCapsule_GetPointer(pynode, "rcl_node_t");
-  if (!node) {
-    return NULL;
-  }
-
-  if (!PyCapsule_CheckExact(pyentity)) {
-    PyErr_Format(PyExc_RuntimeError, "entity is not a capsule");
-    return NULL;
-  }
-
-  rcl_ret_t ret;
-  if (PyCapsule_IsValid(pyentity, "rcl_publisher_t")) {
-    rcl_publisher_t * publisher = (rcl_publisher_t *)PyCapsule_GetPointer(
-      pyentity, "rcl_publisher_t");
-    ret = rcl_publisher_fini(publisher, node);
-    PyMem_Free(publisher);
-  } else if (PyCapsule_IsValid(pyentity, "rcl_client_t")) {
-    rcl_client_t * client = (rcl_client_t *)PyCapsule_GetPointer(pyentity, "rcl_client_t");
-    ret = rcl_client_fini(client, node);
-    PyMem_Free(client);
-  } else if (PyCapsule_IsValid(pyentity, "rcl_service_t")) {
-    rcl_service_t * service = (rcl_service_t *)PyCapsule_GetPointer(pyentity, "rcl_service_t");
-    ret = rcl_service_fini(service, node);
-    PyMem_Free(service);
-  } else {
-    ret = RCL_RET_ERROR;  // to avoid a linter warning
-    PyErr_Format(PyExc_RuntimeError, "'%s' is not a known node entity",
-      PyCapsule_GetName(pyentity));
-    return NULL;
-  }
-  if (ret != RCL_RET_OK) {
-    PyErr_Format(PyExc_RuntimeError,
-      "Failed to fini '%s': %s", PyCapsule_GetName(pyentity), rcl_get_error_string().str);
-    rcl_reset_error();
-    return NULL;
-  }
-
-  if (PyCapsule_SetPointer(pyentity, Py_None)) {
-    // exception set by PyCapsule_SetPointer
-    return NULL;
-  }
-
-  Py_RETURN_NONE;
-}
-
 /// Destructor for a clock
-void
+static void
 _rclpy_destroy_clock(PyObject * pycapsule)
 {
   rcl_clock_t * clock = (rcl_clock_t *)PyCapsule_GetPointer(pycapsule, "rcl_clock_t");
   if (NULL == clock) {
     // exception was set by PyCapsule_GetPointer
+    PyErr_Clear();
+    // Warning should use line number of the current stack frame
+    int stack_level = 1;
+    PyErr_WarnFormat(
+      PyExc_RuntimeWarning, stack_level, "Failed to get clock pointer in destructor");
+    rcl_reset_error();
     return;
   }
 
   rcl_ret_t ret_clock = rcl_clock_fini(clock);
   PyMem_Free(clock);
   if (ret_clock != RCL_RET_OK) {
-    PyErr_Format(PyExc_RuntimeError,
-      "Failed to fini 'rcl_clock_t': %s", rcl_get_error_string().str);
+    // Warning should use line number of the current stack frame
+    int stack_level = 1;
+    PyErr_WarnFormat(
+      PyExc_RuntimeWarning, stack_level, "Failed to fini clock: %s",
+      rcl_get_error_string().str);
     rcl_reset_error();
   }
-}
-
-/// Destroy an rcl entity
-/**
- * Raises RuntimeError on failure
- *
- * \param[in] pyentity Capsule pointing to the entity to destroy
- */
-static PyObject *
-rclpy_destroy_entity(PyObject * Py_UNUSED(self), PyObject * args)
-{
-  PyObject * pyentity;
-
-  if (!PyArg_ParseTuple(args, "O", &pyentity)) {
-    return NULL;
-  }
-
-  if (!PyCapsule_CheckExact(pyentity)) {
-    PyErr_Format(PyExc_ValueError, "Object is not a capsule");
-    return NULL;
-  }
-
-  rcl_ret_t ret;
-  if (PyCapsule_IsValid(pyentity, "rcl_timer_t")) {
-    rcl_timer_t * timer = (rcl_timer_t *)PyCapsule_GetPointer(pyentity, "rcl_timer_t");
-    ret = rcl_timer_fini(timer);
-    PyMem_Free(timer);
-  } else if (PyCapsule_IsValid(pyentity, "rcl_clock_t")) {
-    PyCapsule_SetDestructor(pyentity, NULL);
-    _rclpy_destroy_clock(pyentity);
-    ret = RCL_RET_OK;
-  } else if (PyCapsule_IsValid(pyentity, "rcl_guard_condition_t")) {
-    rcl_guard_condition_t * guard_condition = (rcl_guard_condition_t *)PyCapsule_GetPointer(
-      pyentity, "rcl_guard_condition_t");
-    ret = rcl_guard_condition_fini(guard_condition);
-    PyMem_Free(guard_condition);
-  } else {
-    ret = RCL_RET_ERROR;  // to avoid a linter warning
-    PyErr_Format(PyExc_RuntimeError, "'%s' is not a known entity", PyCapsule_GetName(pyentity));
-    return NULL;
-  }
-  if (ret != RCL_RET_OK) {
-    PyErr_Format(PyExc_RuntimeError,
-      "Failed to fini '%s': %s", PyCapsule_GetName(pyentity), rcl_get_error_string().str);
-    rcl_reset_error();
-    return NULL;
-  }
-
-  if (PyCapsule_SetPointer(pyentity, Py_None)) {
-    // exception set by PyCapsule_SetPointer
-    return NULL;
-  }
-
-  Py_RETURN_NONE;
 }
 
 /// Return the identifier of the current rmw_implementation
@@ -2500,22 +2464,37 @@ rclpy_wait_set_add_entity(PyObject * Py_UNUSED(self), PyObject * args)
   if (0 == strcmp(entity_type, "subscription")) {
     rclpy_subscription_t * sub =
       (rclpy_subscription_t *)PyCapsule_GetPointer(pyentity, "rclpy_subscription_t");
+    if (!sub) {
+      return NULL;
+    }
     ret = rcl_wait_set_add_subscription(wait_set, &(sub->subscription), &index);
   } else if (0 == strcmp(entity_type, "client")) {
-    rcl_client_t * client =
-      (rcl_client_t *)PyCapsule_GetPointer(pyentity, "rcl_client_t");
-    ret = rcl_wait_set_add_client(wait_set, client, &index);
+    rclpy_client_t * client =
+      (rclpy_client_t *)PyCapsule_GetPointer(pyentity, "rclpy_client_t");
+    if (!client) {
+      return NULL;
+    }
+    ret = rcl_wait_set_add_client(wait_set, &(client->client), &index);
   } else if (0 == strcmp(entity_type, "service")) {
-    rcl_service_t * service =
-      (rcl_service_t *)PyCapsule_GetPointer(pyentity, "rcl_service_t");
-    ret = rcl_wait_set_add_service(wait_set, service, &index);
+    rclpy_service_t * srv =
+      (rclpy_service_t *)PyCapsule_GetPointer(pyentity, "rclpy_service_t");
+    if (!srv) {
+      return NULL;
+    }
+    ret = rcl_wait_set_add_service(wait_set, &(srv->service), &index);
   } else if (0 == strcmp(entity_type, "timer")) {
     rcl_timer_t * timer =
       (rcl_timer_t *)PyCapsule_GetPointer(pyentity, "rcl_timer_t");
+    if (!timer) {
+      return NULL;
+    }
     ret = rcl_wait_set_add_timer(wait_set, timer, &index);
   } else if (0 == strcmp(entity_type, "guard_condition")) {
     rcl_guard_condition_t * guard_condition =
       (rcl_guard_condition_t *)PyCapsule_GetPointer(pyentity, "rcl_guard_condition_t");
+    if (!guard_condition) {
+      return NULL;
+    }
     ret = rcl_wait_set_add_guard_condition(wait_set, guard_condition, &index);
   } else {
     ret = RCL_RET_ERROR;  // to avoid a linter warning
@@ -2872,9 +2851,9 @@ rclpy_take_request(PyObject * Py_UNUSED(self), PyObject * args)
     return NULL;
   }
 
-  rcl_service_t * service =
-    (rcl_service_t *)PyCapsule_GetPointer(pyservice, "rcl_service_t");
-  if (!service) {
+  rclpy_service_t * srv =
+    (rclpy_service_t *)PyCapsule_GetPointer(pyservice, "rclpy_service_t");
+  if (!srv) {
     return NULL;
   }
 
@@ -2889,7 +2868,7 @@ rclpy_take_request(PyObject * Py_UNUSED(self), PyObject * args)
     PyErr_Format(PyExc_MemoryError, "Failed to allocate memory for request header");
     return NULL;
   }
-  rcl_ret_t ret = rcl_take_request(service, header, taken_request);
+  rcl_ret_t ret = rcl_take_request(&(srv->service), header, taken_request);
 
   if (ret != RCL_RET_OK && ret != RCL_RET_SERVICE_TAKE_FAILED) {
     PyErr_Format(PyExc_RuntimeError,
@@ -2949,8 +2928,8 @@ rclpy_take_response(PyObject * Py_UNUSED(self), PyObject * args)
   if (!PyArg_ParseTuple(args, "OO", &pyclient, &pyresponse_type)) {
     return NULL;
   }
-  rcl_client_t * client =
-    (rcl_client_t *)PyCapsule_GetPointer(pyclient, "rcl_client_t");
+  rclpy_client_t * client =
+    (rclpy_client_t *)PyCapsule_GetPointer(pyclient, "rclpy_client_t");
   if (!client) {
     return NULL;
   }
@@ -2966,7 +2945,7 @@ rclpy_take_response(PyObject * Py_UNUSED(self), PyObject * args)
     PyErr_Format(PyExc_MemoryError, "Failed to allocate memory for response header");
     return NULL;
   }
-  rcl_ret_t ret = rcl_take_response(client, header, taken_response);
+  rcl_ret_t ret = rcl_take_response(&(client->client), header, taken_response);
   int64_t sequence = header->sequence_number;
   PyMem_Free(header);
 
@@ -4624,15 +4603,6 @@ static PyMethodDef rclpy_methods[] = {
   {
     "rclpy_trigger_guard_condition", rclpy_trigger_guard_condition, METH_VARARGS,
     "Trigger a general purpose guard_condition."
-  },
-
-  {
-    "rclpy_destroy_node_entity", rclpy_destroy_node_entity, METH_VARARGS,
-    "Destroy a Node entity."
-  },
-  {
-    "rclpy_destroy_entity", rclpy_destroy_entity, METH_VARARGS,
-    "Destroy an rclpy entity."
   },
 
   {

--- a/rclpy/test/test_destruction.py
+++ b/rclpy/test/test_destruction.py
@@ -16,6 +16,7 @@ import pytest
 import rclpy
 from rclpy.handle import InvalidHandle
 from test_msgs.msg import Primitives
+from test_msgs.srv import Primitives as PrimitivesSrv
 
 
 def test_destroy_node():
@@ -142,5 +143,121 @@ def test_destroy_node_asap():
             # handle invalid because it was destroyed when no one was using it
             with node.handle:
                 pass
+    finally:
+        rclpy.shutdown(context=context)
+
+
+def test_destroy_publisher_asap():
+    context = rclpy.context.Context()
+    rclpy.init(context=context)
+
+    try:
+        node = rclpy.create_node('test_destroy_publisher_asap', context=context)
+        try:
+            pub = node.create_publisher(Primitives, 'pub_topic')
+
+            # handle valid
+            with pub.handle:
+                pass
+
+            with pub.handle:
+                node.destroy_publisher(pub)
+                # handle valid because it's still being used
+                with pub.handle:
+                    pass
+
+            with pytest.raises(InvalidHandle):
+                # handle invalid because it was destroyed when no one was using it
+                with pub.handle:
+                    pass
+        finally:
+            node.destroy_node()
+    finally:
+        rclpy.shutdown(context=context)
+
+
+def test_destroy_client_asap():
+    context = rclpy.context.Context()
+    rclpy.init(context=context)
+
+    try:
+        node = rclpy.create_node('test_destroy_client_asap', context=context)
+        try:
+            client = node.create_client(PrimitivesSrv, 'cli_service')
+
+            # handle valid
+            with client.handle:
+                pass
+
+            with client.handle:
+                node.destroy_client(client)
+                # handle valid because it's still being used
+                with client.handle:
+                    pass
+
+            with pytest.raises(InvalidHandle):
+                # handle invalid because it was destroyed when no one was using it
+                with client.handle:
+                    pass
+        finally:
+            node.destroy_node()
+    finally:
+        rclpy.shutdown(context=context)
+
+
+def test_destroy_service_asap():
+    context = rclpy.context.Context()
+    rclpy.init(context=context)
+
+    try:
+        node = rclpy.create_node('test_destroy_service_asap', context=context)
+        try:
+            service = node.create_service(PrimitivesSrv, 'srv_service', lambda req, res: ...)
+
+            # handle valid
+            with service.handle:
+                pass
+
+            with service.handle:
+                node.destroy_service(service)
+                # handle valid because it's still being used
+                with service.handle:
+                    pass
+
+            with pytest.raises(InvalidHandle):
+                # handle invalid because it was destroyed when no one was using it
+                with service.handle:
+                    pass
+        finally:
+            node.destroy_node()
+    finally:
+        rclpy.shutdown(context=context)
+
+
+def test_destroy_timer_asap():
+    context = rclpy.context.Context()
+    rclpy.init(context=context)
+
+    try:
+        node = rclpy.create_node('test_destroy_timer_asap', context=context)
+        try:
+            timer = node.create_timer(1.0, lambda: ...)
+
+            # handle valid
+            with timer.handle:
+                pass
+
+            with timer.handle:
+                node.destroy_timer(timer)
+                # handle valid because it's still being used
+                with timer.handle:
+                    pass
+
+            with pytest.raises(InvalidHandle):
+                # handle invalid because it was destroyed when no one was using it
+                with timer.handle:
+                    pass
+        finally:
+            node.destroy_node()
     finally:
         rclpy.shutdown(context=context)

--- a/rclpy/test/test_waitable.py
+++ b/rclpy/test/test_waitable.py
@@ -43,7 +43,7 @@ class ClientWaitable(Waitable):
 
         with node.handle as node_capsule:
             self.client = _rclpy.rclpy_create_client(
-                node_capsule, EmptySrv, 'test_client', qos_profile_default.get_c_qos_profile())[0]
+                node_capsule, EmptySrv, 'test_client', qos_profile_default.get_c_qos_profile())
         self.client_index = None
         self.client_is_ready = False
 
@@ -86,7 +86,7 @@ class ServerWaitable(Waitable):
 
         with node.handle as node_capsule:
             self.server = _rclpy.rclpy_create_service(
-                node_capsule, EmptySrv, 'test_server', qos_profile_default.get_c_qos_profile())[0]
+                node_capsule, EmptySrv, 'test_server', qos_profile_default.get_c_qos_profile())
         self.server_index = None
         self.server_is_ready = False
 
@@ -129,9 +129,9 @@ class TimerWaitable(Waitable):
 
         self._clock = Clock(clock_type=ClockType.STEADY_TIME)
         period_nanoseconds = 10000
-        self.timer = _rclpy.rclpy_create_timer(
-            self._clock._clock_handle, node.context.handle, period_nanoseconds
-        )[0]
+        with self._clock.handle as clock_capsule:
+            self.timer = _rclpy.rclpy_create_timer(
+                clock_capsule, node.context.handle, period_nanoseconds)
         self.timer_index = None
         self.timer_is_ready = False
 
@@ -172,10 +172,6 @@ class SubscriptionWaitable(Waitable):
 
     def __init__(self, node):
         super().__init__(ReentrantCallbackGroup())
-
-        self.guard_condition = _rclpy.rclpy_create_guard_condition(node.context.handle)[0]
-        self.guard_condition_index = None
-        self.guard_is_ready = False
 
         with node.handle as node_capsule:
             self.subscription = _rclpy.rclpy_create_subscription(
@@ -221,7 +217,7 @@ class GuardConditionWaitable(Waitable):
     def __init__(self, node):
         super().__init__(ReentrantCallbackGroup())
 
-        self.guard_condition = _rclpy.rclpy_create_guard_condition(node.context.handle)[0]
+        self.guard_condition = _rclpy.rclpy_create_guard_condition(node.context.handle)
         self.guard_condition_index = None
         self.guard_is_ready = False
 


### PR DESCRIPTION
Recreated from original PR: https://github.com/ros2/rclpy/pull/319

Follow up to ros2/rclpy#318 and ros2/rclpy#330. This PR applies the changes done to `Subscription` to the rest of the entities on the node so they can all be destroyed safely.

- [x] destroy_publisher
- [x] destroy_client
- [x] destroy_service
- [x] destroy_timer
  - [x] Clock used by timer safely destroyed
- [x] destroy_guard_condition


Not done in this PR. These might require a change to the waitable API.

* action server
* action client